### PR TITLE
Patch POSIX pathing, SVG embedding, footnotes opening in new tabs

### DIFF
--- a/assets/webpage.js
+++ b/assets/webpage.js
@@ -80,7 +80,7 @@ jQuery(function()
 		setThemeToggle(!(localStorage.getItem("theme_toggle") == "true"));
     });
 
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => 
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event =>
 	{
 		// return if we are printing
 		if (window.matchMedia('print').matches)
@@ -127,7 +127,7 @@ jQuery(function()
         });
     });
 
-    
+
 
     // MAKE HEADERS COLLAPSIBLE
     // if "heading-collapse-indicator" is clicked, toggle the display of every div until the next heading of the same or lower level
@@ -159,14 +159,14 @@ jQuery(function()
 			if ($(header).hasClass("is-collapsed")) $(header).toggleClass("is-collapsed");
 
             $(header).nextUntil(selector).show();
-			
+
 			// close headers inside of this one that are collapsed
             $(header).nextUntil(selector).each(function()
             {
 				if($(this).hasClass("is-collapsed"))
 					setHeaderCollapse($(this), true);
             });
-			
+
 			//open headers above this one that are collapsed
 			lastHeaderSize = $(header).children().first().prop("tagName").toLowerCase().replace("h", "");
 			$(header).prevAll().each(function()
@@ -218,13 +218,13 @@ jQuery(function()
 
     // MAKE OUTLINE COLLAPSIBLE
     // if "outline-header" is clicked, toggle the display of every div until the next heading of the same or lower level
-    
+
     var outline_width = 0;
 
     $(".outline-item-contents > .collapse-icon").on("click", function()
     {
         var isCollapsed = $(this).parent().parent().hasClass("is-collapsed");
-        
+
         $(this).parent().parent().toggleClass("is-collapsed");
 
         if(isCollapsed)
@@ -235,6 +235,9 @@ jQuery(function()
         {
             $(this).parent().next().slideUp(120);
         }
+
+		// Prevent the collapse button from triggering the parent <a> tag navigation.
+		return false;
     });
 
     // hide the control button if the header has no children

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"devDependencies": {
 		"@types/file-saver": "^2.0.5",
 		"@types/jquery": "^3.5.14",
-		"@types/node": "^16.11.6",
+		"@types/node": "^16.18.11",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -1,14 +1,16 @@
 import {  readFile, writeFile, existsSync, mkdirSync } from 'fs';
 import { FileSystemAdapter, MarkdownView, TextFileView, TFile } from 'obsidian';
 import { ExportSettings } from './settings';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { isAbsolute, normalize, join } from 'path';
+
 
 /* @ts-ignore */
 const dialog: Electron.Dialog = require('electron').remote.dialog;
 
 export class Utils
 {
-	static async delay (ms: number)
+	static async delay(ms: number)
 	{
 		return new Promise( resolve => setTimeout(resolve, ms) );
 	}
@@ -19,20 +21,19 @@ export class Utils
 		return newPath;
 	}
 
-
 	static async getText(path: string): Promise<string>
 	{
 		path = this.fixPath(path);
 
-		if(!existsSync(path))
-		{ 
-			console.log("File not found: " + path); 
+		if (!existsSync(path))
+		{
+			console.log("File not found: " + path);
 			return "";
 		}
 
 		return new Promise((resolve, reject) =>
 		{
-			readFile(path, { encoding: 'utf8' }, (err, data) => 
+			readFile(path, { encoding: 'utf8' }, (err, data) =>
 			{
 				if (err)
 				{
@@ -49,9 +50,9 @@ export class Utils
 		if (!path.startsWith('file:///'))
 		{
 			if (isAbsolute(path))
-				path = pathToFileURL(normalize(path));
+				path = pathToFileURL(normalize(path)).toString();
 			else
-				path = pathToFileURL(normalize(join(this.getVaultPath(), path)));
+				path = pathToFileURL(normalize(join(this.getVaultPath() as string, path))).toString();
 		}
 
 		return fileURLToPath(path);
@@ -63,7 +64,7 @@ export class Utils
 
 		if(!existsSync(path))
 		{
-			console.log("File not found: " + path); 
+			console.log("File not found: " + path);
 			return "";
 		}
 
@@ -71,7 +72,7 @@ export class Utils
 
 		return new Promise((resolve, reject) =>
 		{
-			readFile(path, { encoding: 'base64' }, (err, data) => 
+			readFile(path, { encoding: 'base64' }, (err, data) =>
 			{
 				if (err)
 				{
@@ -86,7 +87,7 @@ export class Utils
 	static changeViewMode(view: MarkdownView, modeName: "preview" | "source")
 	{
 		/*@ts-ignore*/
-		const mode = view.modes[modeName]; 
+		const mode = view.modes[modeName];
 		/*@ts-ignore*/
 		mode && view.setMode(mode);
 	};
@@ -98,7 +99,7 @@ export class Utils
 		// BE BOM
 		byteArray.push(254, 255);
 
-		for (let i = 0; i < content.length; ++i) 
+		for (let i = 0; i < content.length; ++i)
 		{
 			charCode = content.charCodeAt(i);
 
@@ -134,7 +135,7 @@ export class Utils
 		})
 
 		if (picker.canceled) return null;
-		
+
 		let path = picker.filePath ?? "";
 
 		if (path != "")
@@ -142,7 +143,7 @@ export class Utils
 			ExportSettings.settings.lastExportPath = path;
 			ExportSettings.saveSettings();
 		}
-		
+
 		return path;
 	}
 
@@ -195,13 +196,13 @@ export class Utils
 			let array = (files[i].unicode ?? true) ? Utils.createUnicodeArray(files[i].data) : Buffer.from(files[i].data, 'base64');
 
 			let path = (folderPath + "/" + (files[i].relativePath ?? "") + "/" + files[i].filename).replaceAll("\\", "/").replaceAll("//", "/").replaceAll("//", "/");
-			
+
 			let dir = Utils.getDirectoryFromFilePath(path);
 			if (!existsSync(dir))
 			{
 				mkdirSync(dir, { recursive: true });
 			}
-			
+
 			writeFile(Utils.fixPath(path), array, (err) => {
 				if (err) throw err;
 				console.log('The file has been saved at ' + path + '!');
@@ -213,7 +214,7 @@ export class Utils
 	{
 		let forwardIndex = path.lastIndexOf("/");
 		let backwardIndex = path.lastIndexOf("\\");
-		
+
 		let index = forwardIndex > backwardIndex ? forwardIndex : backwardIndex;
 
 		if (index == -1) return "";

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -46,12 +46,12 @@ export class Utils
 
 	static fixPath(path: string) : string
 	{
-		if (!path.contains('file:///'))
+		if (!path.startsWith('file:///'))
 		{
-			if(path.contains(':'))
-				path = 'file:///' + path;
+			if (isAbsolute(path))
+				path = pathToFileURL(normalize(path));
 			else
-				path = fileURLToPath("file:///" + this.getVaultPath() + "/" + path);
+				path = pathToFileURL(normalize(join(this.getVaultPath(), path)));
 		}
 
 		return fileURLToPath(path);


### PR DESCRIPTION
Applies a quick change to use the `"path"` library to normalize and return better file URLs, fixing the embedding of images on Mac and Linux.

Also, while I was at it, I fixed:
- Linked SVGs not using the right encoding when inlined into base64 images.
- Footnote links opening a new tab.
- Autodownload boolean not being used.
- Clicking the collapse icon in the table of contents would still navigate you to the category instead of just collapsing.

Sorry for the whitespace diffs, seems VS Code decided to do some trimming.

Would potentially close #10 