### PR TITLE
Outline icon dynamically changes color

### DIFF
--- a/scripts/html-gen.ts
+++ b/scripts/html-gen.ts
@@ -675,8 +675,8 @@ export class HTMLGenerator
 
 		let headerIconPathEl = document.createElement('path');
 		let headerPathData = "M16.4,16.4c-3.5,0-6.4,2.9-6.4,6.4s2.9,6.4,6.4,6.4s6.4-2.9,6.4-6.4S19.9,16.4,16.4,16.4z M16.4,19.6 c1.8,0,3.2,1.4,3.2,3.2c0,1.8-1.4,3.2-3.2,3.2s-3.2-1.4-3.2-3.2C13.2,21,14.6,19.6,16.4,19.6z M29.2,21.2v3.2H90v-3.2H29.2z M16.4,43.6c-3.5,0-6.4,2.9-6.4,6.4s2.9,6.4,6.4,6.4s6.4-2.9,6.4-6.4S19.9,43.6,16.4,43.6z M16.4,46.8c1.8,0,3.2,1.4,3.2,3.2 s-1.4,3.2-3.2,3.2s-3.2-1.4-3.2-3.2S14.6,46.8,16.4,46.8z M29.2,48.4v3.2H90v-3.2H29.2z M16.4,70.8c-3.5,0-6.4,2.9-6.4,6.4 c0,3.5,2.9,6.4,6.4,6.4s6.4-2.9,6.4-6.4C22.8,73.7,19.9,70.8,16.4,70.8z M16.4,74c1.8,0,3.2,1.4,3.2,3.2c0,1.8-1.4,3.2-3.2,3.2 s-3.2-1.4-3.2-3.2C13.2,75.4,14.6,74,16.4,74z M29.2,75.6v3.2H90v-3.2H29.2z";
-		headerIconPathEl.setAttribute("fill", "var(--h6-color)");
-		headerIconPathEl.setAttribute("stroke", "var(--h6-color)");
+		headerIconPathEl.setAttribute("fill", "var(--color-base-100)");
+		headerIconPathEl.setAttribute("stroke", "var(--color-base-100)");
 		headerIconPathEl.setAttribute("d", headerPathData);
 
 		let headerLabelEl = document.createElement('h6');


### PR DESCRIPTION
I found that in dark themes, the outline icon is still black making it look bad, i made a quick fix for this by changing the fill and stroke color of the svg to color-base-100.

Before-
![image](https://user-images.githubusercontent.com/72494265/214619927-6481b039-7f6a-4422-9b59-9cbc3fcc5d8e.png)

After-
![image](https://user-images.githubusercontent.com/72494265/214620101-d5b9b9ea-390f-46ad-8a46-98eb269ef97b.png)
