### PR TITLE
Mac & Linux POSIX fix + other bug fixes

### DIFF
--- a/assets/webpage.js
+++ b/assets/webpage.js
@@ -236,7 +236,9 @@ jQuery(function()
             $(this).parent().next().slideUp(120);
         }
 
-		e.stopPropagation();
+		// Prevent the collapse button from triggering the parent <a> tag navigation.
+		// fix implented by 'zombony' from GitHub
+		return false;
     });
 
     // hide the control button if the header has no children

--- a/assets/webpage.js
+++ b/assets/webpage.js
@@ -221,7 +221,7 @@ jQuery(function()
     
     var outline_width = 0;
 
-    $(".outline-item-contents > .collapse-icon").on("click", function()
+    $(".outline-item-contents > .collapse-icon").on("click", function(e)
     {
         var isCollapsed = $(this).parent().parent().hasClass("is-collapsed");
         
@@ -235,6 +235,8 @@ jQuery(function()
         {
             $(this).parent().next().slideUp(120);
         }
+
+		e.stopPropagation();
     });
 
     // hide the control button if the header has no children

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
 	"name": "obsidian-webpage-export",
-	"version": "1.0.1",
+	"version": "1.3.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-webpage-export",
-			"version": "1.0.1",
-			"license": "MIT",
+			"version": "1.3.2",
+			"license": "GPL-3.0",
 			"dependencies": {
-				"file-saver": "^2.0.5",
-				"html2pdf.js": "^0.10.1",
 				"jquery": "^3.5.14",
-				"jszip": "^3.10.1"
+				"jszip": "^3.10.1",
+				"upath": "^2.0.1"
 			},
 			"devDependencies": {
 				"@types/file-saver": "^2.0.5",
@@ -27,17 +26,6 @@
 				"obsidian": "^0.16.3",
 				"tslib": "2.4.0",
 				"typescript": "4.7.4"
-			}
-		},
-		"node_modules/@babel/runtime": {
-			"version": "7.20.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-			"integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
-			"dependencies": {
-				"regenerator-runtime": "^0.13.10"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -247,12 +235,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.3.tgz",
 			"integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
 			"dev": true
-		},
-		"node_modules/@types/raf": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
-			"integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
-			"optional": true
 		},
 		"node_modules/@types/sizzle": {
 			"version": "2.3.3",
@@ -535,31 +517,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"bin": {
-				"atob": "bin/atob.js"
-			},
-			"engines": {
-				"node": ">= 4.5.0"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"peer": true
-		},
-		"node_modules/base64-arraybuffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-			"integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-			"engines": {
-				"node": ">= 0.6.0"
-			}
 		},
 		"node_modules/boolean": {
 			"version": "3.2.0",
@@ -589,17 +552,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/btoa": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-			"integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-			"bin": {
-				"btoa": "bin/btoa.js"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
 			}
 		},
 		"node_modules/buffer-crc32": {
@@ -679,25 +631,6 @@
 			"peer": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/canvg": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
-			"integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
-			"optional": true,
-			"dependencies": {
-				"@babel/runtime": "^7.12.5",
-				"@types/raf": "^3.4.0",
-				"core-js": "^3.8.3",
-				"raf": "^3.4.1",
-				"regenerator-runtime": "^0.13.7",
-				"rgbcolor": "^1.0.1",
-				"stackblur-canvas": "^2.0.0",
-				"svg-pathdata": "^6.0.3"
-			},
-			"engines": {
-				"node": ">=10.0.0"
 			}
 		},
 		"node_modules/chalk": {
@@ -782,17 +715,6 @@
 				"proto-list": "~1.2.1"
 			}
 		},
-		"node_modules/core-js": {
-			"version": "3.26.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
-			"integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw==",
-			"hasInstallScript": true,
-			"optional": true,
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/core-js"
-			}
-		},
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -811,14 +733,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/css-line-break": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-			"integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-			"dependencies": {
-				"utrie": "^1.0.2"
 			}
 		},
 		"node_modules/debug": {
@@ -912,12 +826,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/dompurify": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
-			"integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA==",
-			"optional": true
-		},
 		"node_modules/duplexer3": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -976,11 +884,6 @@
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
 			"dev": true,
 			"optional": true
-		},
-		"node_modules/es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
 		},
 		"node_modules/esbuild": {
 			"version": "0.14.47",
@@ -1657,11 +1560,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"node_modules/fflate": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-			"integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
-		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1674,11 +1572,6 @@
 			"engines": {
 				"node": "^10.12.0 || >=12.0.0"
 			}
-		},
-		"node_modules/file-saver": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
-			"integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
 		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
@@ -1995,28 +1888,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/html2canvas": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-			"integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-			"dependencies": {
-				"css-line-break": "^2.1.0",
-				"text-segmentation": "^1.0.3"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/html2pdf.js": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.10.1.tgz",
-			"integrity": "sha512-3onwwhOWsZfNjIZwV6YIJ6FVhXk+X9YxHSqzeS6hup+1dGi2DHI+zZYUJ+iFnvtaYcjlhyrILL1fvRCUOa8Fcg==",
-			"dependencies": {
-				"es6-promise": "^4.2.5",
-				"html2canvas": "^1.0.0",
-				"jspdf": "^2.3.1"
-			}
-		},
 		"node_modules/http-cache-semantics": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -2199,23 +2070,6 @@
 			"dev": true,
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/jspdf": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
-			"integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
-			"dependencies": {
-				"@babel/runtime": "^7.14.0",
-				"atob": "^2.1.2",
-				"btoa": "^1.2.1",
-				"fflate": "^0.4.8"
-			},
-			"optionalDependencies": {
-				"canvg": "^3.0.6",
-				"core-js": "^3.6.0",
-				"dompurify": "^2.2.0",
-				"html2canvas": "^1.0.0-rc.5"
 			}
 		},
 		"node_modules/jszip": {
@@ -2589,12 +2443,6 @@
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
 			"dev": true
 		},
-		"node_modules/performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-			"optional": true
-		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2697,15 +2545,6 @@
 				}
 			]
 		},
-		"node_modules/raf": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-			"optional": true,
-			"dependencies": {
-				"performance-now": "^2.1.0"
-			}
-		},
 		"node_modules/readable-stream": {
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -2719,11 +2558,6 @@
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
 			}
-		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.13.10",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-			"integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
 		},
 		"node_modules/regexpp": {
 			"version": "3.2.0",
@@ -2764,15 +2598,6 @@
 			"engines": {
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/rgbcolor": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-			"integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-			"optional": true,
-			"engines": {
-				"node": ">= 0.8.15"
 			}
 		},
 		"node_modules/rimraf": {
@@ -2932,15 +2757,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"node_modules/stackblur-canvas": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
-			"integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
-			"optional": true,
-			"engines": {
-				"node": ">=0.1.14"
-			}
-		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3005,23 +2821,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/svg-pathdata": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-			"integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-			"optional": true,
-			"engines": {
-				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/text-segmentation": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-			"integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-			"dependencies": {
-				"utrie": "^1.0.2"
 			}
 		},
 		"node_modules/text-table": {
@@ -3143,6 +2942,15 @@
 				"node": ">= 4.0.0"
 			}
 		},
+		"node_modules/upath": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+			"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
+			"engines": {
+				"node": ">=4",
+				"yarn": "*"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3169,14 +2977,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-		},
-		"node_modules/utrie": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-			"integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-			"dependencies": {
-				"base64-arraybuffer": "^1.0.2"
-			}
 		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.6",
@@ -3248,14 +3048,6 @@
 		}
 	},
 	"dependencies": {
-		"@babel/runtime": {
-			"version": "7.20.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.1.tgz",
-			"integrity": "sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==",
-			"requires": {
-				"regenerator-runtime": "^0.13.10"
-			}
-		},
 		"@codemirror/state": {
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.2.tgz",
@@ -3427,12 +3219,6 @@
 			"integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
 			"dev": true
 		},
-		"@types/raf": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
-			"integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
-			"optional": true
-		},
 		"@types/sizzle": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
@@ -3601,22 +3387,12 @@
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true
 		},
-		"atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"peer": true
-		},
-		"base64-arraybuffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-			"integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ=="
 		},
 		"boolean": {
 			"version": "3.2.0",
@@ -3644,11 +3420,6 @@
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
-		},
-		"btoa": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-			"integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g=="
 		},
 		"buffer-crc32": {
 			"version": "0.2.13",
@@ -3706,22 +3477,6 @@
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true,
 			"peer": true
-		},
-		"canvg": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
-			"integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
-			"optional": true,
-			"requires": {
-				"@babel/runtime": "^7.12.5",
-				"@types/raf": "^3.4.0",
-				"core-js": "^3.8.3",
-				"raf": "^3.4.1",
-				"regenerator-runtime": "^0.13.7",
-				"rgbcolor": "^1.0.1",
-				"stackblur-canvas": "^2.0.0",
-				"svg-pathdata": "^6.0.3"
-			}
 		},
 		"chalk": {
 			"version": "4.1.2",
@@ -3790,12 +3545,6 @@
 				"proto-list": "~1.2.1"
 			}
 		},
-		"core-js": {
-			"version": "3.26.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.26.0.tgz",
-			"integrity": "sha512-+DkDrhoR4Y0PxDz6rurahuB+I45OsEUv8E1maPTB6OuHRohMMcznBq9TMpdpDMm/hUPob/mJJS3PqgbHpMTQgw==",
-			"optional": true
-		},
 		"core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -3811,14 +3560,6 @@
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
-			}
-		},
-		"css-line-break": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-			"integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-			"requires": {
-				"utrie": "^1.0.2"
 			}
 		},
 		"debug": {
@@ -3889,12 +3630,6 @@
 				"esutils": "^2.0.2"
 			}
 		},
-		"dompurify": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
-			"integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA==",
-			"optional": true
-		},
 		"duplexer3": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
@@ -3940,11 +3675,6 @@
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
 			"dev": true,
 			"optional": true
-		},
-		"es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
 		},
 		"esbuild": {
 			"version": "0.14.47",
@@ -4374,11 +4104,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"fflate": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-			"integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
-		},
 		"file-entry-cache": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4388,11 +4113,6 @@
 			"requires": {
 				"flat-cache": "^3.0.4"
 			}
-		},
-		"file-saver": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
-			"integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
 		},
 		"fill-range": {
 			"version": "7.0.1",
@@ -4637,25 +4357,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"html2canvas": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-			"integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-			"requires": {
-				"css-line-break": "^2.1.0",
-				"text-segmentation": "^1.0.3"
-			}
-		},
-		"html2pdf.js": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.10.1.tgz",
-			"integrity": "sha512-3onwwhOWsZfNjIZwV6YIJ6FVhXk+X9YxHSqzeS6hup+1dGi2DHI+zZYUJ+iFnvtaYcjlhyrILL1fvRCUOa8Fcg==",
-			"requires": {
-				"es6-promise": "^4.2.5",
-				"html2canvas": "^1.0.0",
-				"jspdf": "^2.3.1"
-			}
-		},
 		"http-cache-semantics": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -4811,21 +4512,6 @@
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
-			}
-		},
-		"jspdf": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
-			"integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
-			"requires": {
-				"@babel/runtime": "^7.14.0",
-				"atob": "^2.1.2",
-				"btoa": "^1.2.1",
-				"canvg": "^3.0.6",
-				"core-js": "^3.6.0",
-				"dompurify": "^2.2.0",
-				"fflate": "^0.4.8",
-				"html2canvas": "^1.0.0-rc.5"
 			}
 		},
 		"jszip": {
@@ -5114,12 +4800,6 @@
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
 			"dev": true
 		},
-		"performance-now": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-			"optional": true
-		},
 		"picomatch": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -5187,15 +4867,6 @@
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
 		},
-		"raf": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-			"optional": true,
-			"requires": {
-				"performance-now": "^2.1.0"
-			}
-		},
 		"readable-stream": {
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -5209,11 +4880,6 @@
 				"string_decoder": "~1.1.1",
 				"util-deprecate": "~1.0.1"
 			}
-		},
-		"regenerator-runtime": {
-			"version": "0.13.10",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-			"integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
 		},
 		"regexpp": {
 			"version": "3.2.0",
@@ -5242,12 +4908,6 @@
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
 			"dev": true
-		},
-		"rgbcolor": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-			"integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-			"optional": true
 		},
 		"rimraf": {
 			"version": "3.0.2",
@@ -5358,12 +5018,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"stackblur-canvas": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
-			"integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
-			"optional": true
-		},
 		"string_decoder": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -5413,20 +5067,6 @@
 			"peer": true,
 			"requires": {
 				"has-flag": "^4.0.0"
-			}
-		},
-		"svg-pathdata": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-			"integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-			"optional": true
-		},
-		"text-segmentation": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-			"integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-			"requires": {
-				"utrie": "^1.0.2"
 			}
 		},
 		"text-table": {
@@ -5516,6 +5156,11 @@
 			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
 			"dev": true
 		},
+		"upath": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
+			"integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w=="
+		},
 		"uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5539,14 +5184,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-		},
-		"utrie": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-			"integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-			"requires": {
-				"base64-arraybuffer": "^1.0.2"
-			}
 		},
 		"w3c-keyname": {
 			"version": "2.2.6",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	},
 	"dependencies": {
 		"jquery": "^3.5.14",
-		"jszip": "^3.10.1"
+		"jszip": "^3.10.1",
+		"upath": "^2.0.1"
 	}
 }

--- a/scripts/html-gen.ts
+++ b/scripts/html-gen.ts
@@ -17,7 +17,7 @@ export class HTMLGenerator
 
 	// this is a list of images that is populated during generation and then downloaded upon export
 	// I am sure there is a better way to handle this data flow but I am not sure what to do.
-	private outlinedImages: { original_path: string, destination_path_rel: string }[] = [];
+	private outlinedImages: { localImagePath: string, relativeExportImagePath: string }[] = [];
 
 	// this is a string containing the filtered app.css file. It is populated on load. 
 	// The math styles are attempted to load on every export until they are succesfully loaded. 
@@ -173,13 +173,14 @@ export class HTMLGenerator
 			for (let i = 0; i < this.outlinedImages.length; i++)
 			{
 				let image = this.outlinedImages[i];
-				let data = await Utils.getTextBase64(image.original_path);
+				let data = await Utils.getTextBase64(image.localImagePath);
+				let destinationPath = Utils.parsePath(image.relativeExportImagePath);
 				let imageDownload =
 				{
-					filename: Utils.getFileNameFromFilePath(image.destination_path_rel),
+					filename: destinationPath.base,
 					data: data,
 					type: "image/png",
-					relativePath: Utils.getDirectoryFromFilePath(image.destination_path_rel),
+					relativePath: destinationPath.dir,
 					unicode: false
 				};
 				toDownload.push(imageDownload);
@@ -249,7 +250,7 @@ export class HTMLGenerator
 		if (returnEl == true)
 			return htmlEl;
 		else
-			return "<!DOCTYPE html>\n" + htmlEl.outerHTML;
+			return Utils.beautifyHTML("<!DOCTYPE html>\n" + htmlEl.outerHTML);
 	}
 
 	private generateSideBars(middleContent: HTMLElement, leftContent: HTMLElement, rightContent: HTMLElement): HTMLDivElement
@@ -419,7 +420,6 @@ export class HTMLGenerator
 	//#endregion
 
 	//#region Links and Images
-
 	private fixLinks(page: HTMLElement)
 	{
 		let query = jQuery(page);
@@ -428,69 +428,63 @@ export class HTMLGenerator
 			$(this).attr("target", "_self");
 
 			let finalHref = "";
-			let href = $(this).attr("href")?.split("#");
-
+			let href = $(this).attr("href");
 			if (!href) return;
 
-			// if the file doesn't start with #, then it links to a file, or a header in another file.
-			if (href[0] != "") // href[0] is everything that came before the #, if there was a #.
+			if (href.startsWith("#")) // link pointing to header of this document
 			{
+				finalHref = "#" + href.slice(1).replaceAll(" ", "_").replaceAll("#", "");
+			}
+			else // if it doesn't start with #, it's a link to another document
+			{
+				let headers = href.split("#");
+
 				// find the file that matches the link
 				let currentFile = app.workspace.getActiveFile();
 				if (!currentFile) return;
 
-				let bestPath = app.metadataCache.getFirstLinkpathDest(href[0], currentFile.path)?.path;
+				let bestPath = app.metadataCache.getFirstLinkpathDest(headers[0], currentFile.path)?.path;
 				if (!bestPath) return;
-
-				bestPath = Utils.trimEnd(Utils.trimEnd(bestPath, ".md"), ".canvas");
+				
 				let fileDepth = currentFile.path.split("/").length - 1;
 				for (let i = 0; i < fileDepth; i++)
 				{
 					bestPath = "../" + bestPath;
 				}
+				
+				// get the targeted header name if there is one
+				headers.shift(); // remove the file name from headers list
+				let header = "#" + headers.join("-").replaceAll(" ", "_");
 
-				console.log("bestPath: " + bestPath); 
+				finalHref = bestPath + ".html" + header;
 
-				if (href.length == 1)
-				{
-					finalHref = bestPath + ".html"; 
-				}
+				// if (href.length == 1)
+				// {
+				// 	finalHref = bestPath + ".html"; 
+				// }
 
-				if (href.length == 2)
-				{
-					let filePath = "";
-					if (!bestPath.contains("/") && !bestPath.contains("\\"))
-					{
-						filePath = Utils.getDirectoryFromFilePath(Utils.getFirstFileByName(bestPath)?.path ?? "") + "/";
-					}
+				// if (href.length == 2)
+				// {
+				// 	let filePath = "";
+				// 	if (!bestPath.contains("/") && !bestPath.contains("\\"))
+				// 	{
+				// 		filePath = Utils.getDirectoryFromFilePath(Utils.findFileInVaultByName(bestPath)?.path ?? "") + "/";
+				// 	}
 
-					finalHref = filePath + bestPath + ".html#" + href[1].replaceAll(" ", "_").replaceAll("#", "").replaceAll("__", "_");
-				}
+				// 	finalHref = filePath + bestPath + ".html#" + href[1].replaceAll(" ", "_").replaceAll("#", "").replaceAll("__", "_");
+				// }
 
-				if (href.length > 2)
-				{
-					href.shift();
-					let filePath = "";
-					if (!bestPath.contains("/") && !bestPath.contains("\\"))
-					{
-						filePath = Utils.getDirectoryFromFilePath(Utils.getFirstFileByName(bestPath)?.path ?? "") + "/";
-					}
+				// if (href.length > 2)
+				// {
+				// 	href.shift();
+				// 	let filePath = "";
+				// 	if (!bestPath.contains("/") && !bestPath.contains("\\"))
+				// 	{
+				// 		filePath = Utils.getDirectoryFromFilePath(Utils.findFileInVaultByName(bestPath)?.path ?? "") + "/";
+				// 	}
 
-					finalHref = filePath + bestPath + ".html#" + href.join("#").replaceAll(" ", "_").replaceAll("#", "").replaceAll("__", "_");
-				}
-			}
-			else // if the file starts with #, then it links to an internal header.
-			{
-				href.shift();
-				if (href.length == 1)
-				{
-					finalHref = "#" + href[0].replaceAll(" ", "_").replaceAll("#", "").replaceAll("__", "_");
-				}
-
-				if (href.length > 1)
-				{
-					finalHref = href.join("#").replaceAll(" ", "_").replaceAll("#", "").replaceAll("__", "_");
-				}
+				// 	finalHref = filePath + bestPath + ".html#" + href.join("#").replaceAll(" ", "_").replaceAll("#", "").replaceAll("__", "_");
+				// }
 			}
 
 			$(this).attr("href", finalHref);
@@ -499,7 +493,7 @@ export class HTMLGenerator
 		query.find("h1, h2, h3, h4, h5, h6").each(function ()
 		{
 			// use the headers inner text as the id
-			$(this).attr("id", $(this).text().replaceAll(" ", "_").replaceAll("#", "").replaceAll("__", "_"));
+			$(this).attr("id", $(this).text().replaceAll(" ", "_").replaceAll("#", ""));
 		});
 	}
 
@@ -511,27 +505,26 @@ export class HTMLGenerator
 		for (let i = 0; i < images.length; i++)
 		{
 			let img = images[i];
-			if ($(img).attr("src")?.startsWith("app://local/"))
+			if (!$(img).attr("src")?.startsWith("app://local/")) continue;
+			
+			let path = $(img).attr("src")?.replace("app://local/", "").split("?")[0];
+
+			if (path)
 			{
-				let path = $(img).attr("src")?.replace("app://local/", "file:///").split("?")[0];
-
-				if (path)
+				let base64 = "";
+				try
 				{
-					let base64 = "";
-					try
-					{
-						base64 = await Utils.getTextBase64(path);
-					}
-					catch (e)
-					{
-						console.error(e);
-						console.warn("Failed to inline image: " + path);
-						new Notice("Failed to inline image: " + path, 5000);
-						continue;
-					}
-
-					$(img).attr("src", "data:image/png;base64," + base64);
+					base64 = await Utils.getTextBase64(path);
 				}
+				catch (e)
+				{
+					console.error(e);
+					console.warn("Failed to inline image: " + path);
+					new Notice("Failed to inline image: " + path, 5000);
+					continue;
+				}
+
+				$(img).attr("src", "data:image/png;base64," + base64);
 			}
 		}
 	}
@@ -542,41 +535,38 @@ export class HTMLGenerator
 
 		this.outlinedImages = [];
 
-		let img2Download: { original_path: string, destination_path_rel: string }[] = [];
-		let vaultPath = Utils.getVaultPath();
+		let imagesToOutline: { localImagePath: string, relativeExportImagePath: string }[] = [];
 
 		query.find("img").each(function ()
 		{
 			if (!$(this).attr("src")?.startsWith("app://local/")) return;
 
-			let originalPath = $(this).attr("src")?.replaceAll("\\", "/").replaceAll("%20", " ").replace("app://local/", "");
-
-			// console.log("originalPath: " + originalPath);
-
-			if (!originalPath)
+			let imagePathOriginal = $(this).attr("src")?.replace("app://local/", "").split("?")[0];
+			if (!imagePathOriginal)
 			{
-				new Notice("Failed to outline image: " + originalPath + ". Couldn't find image src", 5000);
+				new Notice("Failed to outline image: " + imagePathOriginal + ". Couldn't find image src", 5000);
+				console.warn("Failed to outline image: " + imagePathOriginal + ". Couldn't find image src");
 				return;
 			}
+			if (imagePathOriginal.startsWith("data:image/png;base64,") || imagePathOriginal.startsWith("data:image/jpeg;base64,")) return;
 
-			if (originalPath.startsWith("data:image/png;base64,") || originalPath.startsWith("data:image/jpeg;base64,")) return;
+			imagePathOriginal = Utils.getAbsolutePath(imagePathOriginal);
+			if (!imagePathOriginal) return;
 
-			let relPath = originalPath.split(Utils.getDirectoryFromFilePath(vaultPath + "/" + view.file.path.replaceAll("\\", "/")) + "/")[1];
+			let continingFilePath = Utils.getAbsolutePath(view.file.path);
+			if (!continingFilePath) return;
 
-			// console.log(originalPath, "vs.", Utils.getDirectoryFromFilePath(vaultPath + "/" + view.file.path.replaceAll("\\", "/")) + "/");
+			let relativeImagePath = Utils.getRelativePath(imagePathOriginal, continingFilePath);
+			if (relativeImagePath.startsWith("..")) relativeImagePath = Utils.joinPaths("/images", Utils.parsePath(imagePathOriginal).base);
 
-			if (!relPath)
-				relPath = ("images/" + Utils.getFileNameFromFilePath($(this).attr("src")?.replaceAll("\\", "/").replaceAll("%20", " ") ?? "")) ?? "img.png";
+			console.log("relative image path: " + relativeImagePath);
 
-			// console.log("relPath: " + relPath);
+			$(this).attr("src", relativeImagePath);
 
-			$(this).attr("src", relPath);
-
-			img2Download.push({ original_path: originalPath, destination_path_rel: relPath });
-
+			imagesToOutline.push({ localImagePath: imagePathOriginal, relativeExportImagePath: relativeImagePath });
 		});
 
-		this.outlinedImages = img2Download;
+		this.outlinedImages = imagesToOutline;
 	}
 
 	//#endregion

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -7,6 +7,7 @@ import { Utils } from './utils';
 import { LeafHandler } from './leaf-handler';
 import { HTMLGenerator } from './html-gen';
 const {shell} = require('electron') 
+const pathTools = require('path');
 
 export default class HTMLExportPlugin extends Plugin
 {
@@ -35,6 +36,8 @@ export default class HTMLExportPlugin extends Plugin
 			});
 		});
 	}
+
+	
 
 	async addCommands()
 	{
@@ -159,6 +162,14 @@ export default class HTMLExportPlugin extends Plugin
 			}
 		}
 
+		let parsedPath = Utils.parsePath(fullPath);
+		if (fullPath == "") 
+		{
+			let saveDialogPath = await Utils.showSaveDialog(Utils.idealDefaultPath(), file.basename + ".html", false) ?? undefined;
+			if (saveDialogPath == undefined) return false;
+			parsedPath = Utils.parsePath(saveDialogPath);
+		}
+
 		let fileTab = this.leafHandler.openFileInNewLeaf(file as TFile, true);
 
 		let htmlEl : string | HTMLHtmlElement | null = await this.htmlGenerator.getCurrentFileHTML();
@@ -171,7 +182,7 @@ export default class HTMLExportPlugin extends Plugin
 
 		let htmlText = (htmlEl instanceof HTMLHtmlElement) ? htmlEl.outerHTML : htmlEl;
 
-		let toDownload = await this.htmlGenerator.getSeperateFilesToDownload();
+		let filesToDownload = await this.htmlGenerator.getSeperateFilesToDownload();
 
 		// Close the file tab after HTML is generated
 		fileTab.detach();
@@ -185,22 +196,16 @@ export default class HTMLExportPlugin extends Plugin
 
 		// Download files
 		let htmlDownload = { filename: file.basename + ".html", data: htmlText, type: "text/html" };
-		toDownload.push(htmlDownload);
+		filesToDownload.unshift(htmlDownload);
 
-		let htmlPath: string | null = fullPath;
-		if (htmlPath == "")
-			htmlPath = await Utils.showSaveDialog(Utils.idealDefaultPath(), file.basename + ".html", false);
+		let filename = parsedPath.base;
+		let folderPath = parsedPath.dir;
 
-		if (!htmlPath) return false;
+		filesToDownload[0].filename = filename;
 
-		let filename = Utils.getFileNameFromFilePath(htmlPath);
-		let folderPath = Utils.getDirectoryFromFilePath(htmlPath);
+		await Utils.downloadFiles(filesToDownload, folderPath);
 
-		toDownload[toDownload.length - 1].filename = filename;
-
-		await Utils.downloadFiles(toDownload, folderPath);
-
-		new Notice("Exported " + file.name + " to " + htmlPath, 5000);
+		new Notice("Exported " + file.name + " to " + parsedPath.fullPath, 5000);
 
 		return true;
 	}
@@ -231,7 +236,7 @@ export default class HTMLExportPlugin extends Plugin
 			}
 		}
 
-		let htmlPath = await Utils.showSelectFolderDialog(Utils.getDirectoryFromFilePath(Utils.idealDefaultPath()));
+		let htmlPath = await Utils.showSelectFolderDialog(Utils.parsePath(Utils.idealDefaultPath()).dir);
 		if (!htmlPath) return false;
 
 		let files = this.app.vault.getFiles();
@@ -241,12 +246,12 @@ export default class HTMLExportPlugin extends Plugin
 			let file = files[i];
 			if (file.path.startsWith(folderPath) && file.extension == "md")
 			{
-				let fullPath = htmlPath + "/" + Utils.getDirectoryFromFilePath(file.path) + "/" + file.basename + ".html";
+				let fullPath = Utils.joinPaths(htmlPath, Utils.parsePath(file.path).dir, file.basename + ".html");
 				await this.exportFile(file, fullPath, false);
 			}
 		}
 
-		new Notice("Folder exported " + folderPath + " to " + htmlPath, 7000);
+		new Notice("Folder exported " + folderPath + " to " + htmlPath, 10000);
 
 		return true;
 	}

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -72,6 +72,8 @@ export default class HTMLExportPlugin extends Plugin
 	{
 		console.log('loading webpage-html-export plugin');
 
+		//"app://local/" + Utils.getAbsolutePath(Utils.makeRelative(".obsidian/plugins/webpage-html-export/webpage.js"));
+
 		// init settings
 		new ExportSettings(this);
 		ExportSettings.loadSettings();

--- a/scripts/main.ts
+++ b/scripts/main.ts
@@ -72,7 +72,6 @@ export default class HTMLExportPlugin extends Plugin
 	{
 		console.log('loading webpage-html-export plugin');
 
-		//"app://local/" + Utils.getAbsolutePath(Utils.makeRelative(".obsidian/plugins/webpage-html-export/webpage.js"));
 
 		// init settings
 		new ExportSettings(this);

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -30,6 +30,11 @@ export class Utils
 		return { root: parsed.root, dir: parsed.dir, base: parsed.base, ext: parsed.ext, name: parsed.name, fullPath: fullPath };
 	}
 
+	static parseFullPath(path: string): string
+	{
+		return this.parsePath(path).fullPath;
+	}
+
 	static joinPaths(...paths: string[]): string
 	{
 		return this.makePathUnicodeCompatible(pathTools.join(...paths));
@@ -51,7 +56,7 @@ export class Utils
 	{
 		path = this.parsePath(this.getAbsolutePath(path, false) ?? path).dir;
 
-		console.log("Checking directory: " + path);
+		console.log("Checking directory exists: " + path);
 
 		if (!this.pathExists(path, false))
 		{
@@ -79,11 +84,11 @@ export class Utils
 		}
 	}
 
-	static makeRelative(path: string): string
+	static forceRelativePath(path: string, forcePOSIX: boolean = false): string
 	{
 		path = path.replaceAll("\\", "/");
 
-		if(process.platform == "win32")
+		if(process.platform == "win32" && !forcePOSIX)
 		{
 			if(!path.startsWith("/")) return "/" + path;
 		}
@@ -95,9 +100,25 @@ export class Utils
 		return path;
 	}
 
+	static forceAbsolutePath(path: string, forcePOSIX: boolean = false): string
+	{
+		path = path.replaceAll("\\", "/");
+
+		if(process.platform == "win32" && !forcePOSIX)
+		{
+			if(path.startsWith("/")) return path = Utils.trimStart(path, "/");
+		}
+		else
+		{
+			if(!path.startsWith("/")) return "/" + path;
+		}
+
+		return path;
+	}
+
 	static getAbsolutePath(path: string, mustExist: boolean = true, workingDirectory: string = this.getVaultPath()): string | undefined
 	{
-		let reliablePath = this.parsePath(path).fullPath;
+		let reliablePath = this.parseFullPath(path);
 
 		if (!Utils.pathIsAbsolute(reliablePath))
 		{


### PR DESCRIPTION
Fixes the POSIX file paths and in general overhauls the way paths are handled to increase reliability.

Other fixes:
- Allow any type of embedded base64 image
- Open footnotes with `_self`
- Clicking the collapse icon in the table of contents would still navigate you to the category instead of just collapsing (thanks to zambony)

fix: #10 and possibly #20