### PR TITLE
Add semicolons to fix graph_view.js minification

### DIFF
--- a/assets/graph_view.txt.js
+++ b/assets/graph_view.txt.js
@@ -206,13 +206,13 @@ class GraphAssembly
 
 class GraphRenderWorker
 {
-    #cameraOffset
-    #cameraScale
-    #hoveredNode
-    #grabbedNode
-    #colors
-    #width
-    #height
+    #cameraOffset;
+    #cameraScale;
+    #hoveredNode;
+    #grabbedNode;
+    #colors;
+    #width;
+    #height;
 
 
     constructor()


### PR DESCRIPTION
I published my Vault on a website that uses Cloudflare's minification and noticed the graph isn't rendering at all. Upon further inspection, I've realized that Cloudflare doesn't minify the graph_view.js script correctly. Adding a few semicolons fixed that issue for me :)