### PR TITLE
Fix url is not decoded before comparison

### DIFF
--- a/assets/webpage.txt.js
+++ b/assets/webpage.txt.js
@@ -430,7 +430,7 @@ function setActiveDocument(url, scrollTo = true, pushHistory = true)
 	let treeItem = undefined;
 	for (let item of treeItems) 
 	{
-		if (item.getAttribute("href") == url)
+		if (item.getAttribute("href") == decodeURI(url))
 		{
 			let parent = item.parentElement.parentElement;
 
@@ -443,7 +443,7 @@ function setActiveDocument(url, scrollTo = true, pushHistory = true)
 				parent = parent.parentElement.parentElement;
 			}
 
-			continue;
+			break;
 		}
 	}
 


### PR DESCRIPTION
If the name of the file had a character that required URL encoding (eg. A white space), it wasn't finding the item to mark it as selected. Also, we don't need to continue searching if we already found it, so we now break from the loop.