### PR TITLE
Incremental export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,26 +9,20 @@
 			"version": "1.3.2",
 			"license": "GPL-3.0",
 			"dependencies": {
-				"jquery": "^3.5.14",
 				"js-beautify": "^1.14.7",
 				"upath": "^2.0.1"
 			},
 			"devDependencies": {
-				"@types/file-saver": "^2.0.5",
-				"@types/jquery": "^3.5.14",
 				"@types/js-beautify": "^1.13.3",
 				"@types/node": "^16.11.6",
-				"@types/victor": "^1.1.0",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
 				"electron": "^18.3.15",
 				"esbuild": "0.14.47",
-				"jquery": "^3.5.14",
 				"obsidian": "^0.16.3",
 				"tslib": "2.4.0",
-				"typescript": "4.7.4",
-				"victor": "^1.1.0"
+				"typescript": "4.7.4"
 			}
 		},
 		"node_modules/@codemirror/state": {
@@ -212,21 +206,6 @@
 			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
 			"dev": true
 		},
-		"node_modules/@types/file-saver": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
-			"integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
-			"dev": true
-		},
-		"node_modules/@types/jquery": {
-			"version": "3.5.14",
-			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
-			"integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
-			"dev": true,
-			"dependencies": {
-				"@types/sizzle": "*"
-			}
-		},
 		"node_modules/@types/js-beautify": {
 			"version": "1.13.3",
 			"resolved": "https://registry.npmjs.org/@types/js-beautify/-/js-beautify-1.13.3.tgz",
@@ -245,12 +224,6 @@
 			"integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
 			"dev": true
 		},
-		"node_modules/@types/sizzle": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-			"integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-			"dev": true
-		},
 		"node_modules/@types/tern": {
 			"version": "0.23.4",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
@@ -259,12 +232,6 @@
 			"dependencies": {
 				"@types/estree": "*"
 			}
-		},
-		"node_modules/@types/victor": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@types/victor/-/victor-1.1.0.tgz",
-			"integrity": "sha512-37o+SnbGRoWqb2+6GQ3NoFX8Ff5zCvm0XsXFulNvO89t2zKluqb4twVORheAnmQ+iEd0rKzAcBGC2//3XBoU1A==",
-			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.29.0",
@@ -2058,12 +2025,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/jquery": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-			"integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
-			"dev": true
-		},
 		"node_modules/js-beautify": {
 			"version": "1.14.7",
 			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
@@ -3079,12 +3040,6 @@
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
 		},
-		"node_modules/victor": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/victor/-/victor-1.1.0.tgz",
-			"integrity": "sha512-s+EQHqIs5TNgLa3HHPr8oCpWFulQZzDX/PLaskVDeWXqEW12l54H5XD+cZ3gXrgvdOscqEcdAMXgEUZlJckQ4w==",
-			"dev": true
-		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.6",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
@@ -3298,21 +3253,6 @@
 			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
 			"dev": true
 		},
-		"@types/file-saver": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@types/file-saver/-/file-saver-2.0.5.tgz",
-			"integrity": "sha512-zv9kNf3keYegP5oThGLaPk8E081DFDuwfqjtiTzm6PoxChdJ1raSuADf2YGCVIyrSynLrgc8JWv296s7Q7pQSQ==",
-			"dev": true
-		},
-		"@types/jquery": {
-			"version": "3.5.14",
-			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
-			"integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
-			"dev": true,
-			"requires": {
-				"@types/sizzle": "*"
-			}
-		},
 		"@types/js-beautify": {
 			"version": "1.13.3",
 			"resolved": "https://registry.npmjs.org/@types/js-beautify/-/js-beautify-1.13.3.tgz",
@@ -3331,12 +3271,6 @@
 			"integrity": "sha512-jh6m0QUhIRcZpNv7Z/rpN+ZWXOicUUQbSoWks7Htkbb9IjFQj4kzcX/xFCkjstCj5flMsN8FiSvt+q+Tcs4Llg==",
 			"dev": true
 		},
-		"@types/sizzle": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-			"integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-			"dev": true
-		},
 		"@types/tern": {
 			"version": "0.23.4",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.4.tgz",
@@ -3345,12 +3279,6 @@
 			"requires": {
 				"@types/estree": "*"
 			}
-		},
-		"@types/victor": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@types/victor/-/victor-1.1.0.tgz",
-			"integrity": "sha512-37o+SnbGRoWqb2+6GQ3NoFX8Ff5zCvm0XsXFulNvO89t2zKluqb4twVORheAnmQ+iEd0rKzAcBGC2//3XBoU1A==",
-			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
 			"version": "5.29.0",
@@ -4602,12 +4530,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"jquery": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
-			"integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
-			"dev": true
-		},
 		"js-beautify": {
 			"version": "1.14.7",
 			"resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
@@ -5362,12 +5284,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-			"dev": true
-		},
-		"victor": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/victor/-/victor-1.1.0.tgz",
-			"integrity": "sha512-s+EQHqIs5TNgLa3HHPr8oCpWFulQZzDX/PLaskVDeWXqEW12l54H5XD+cZ3gXrgvdOscqEcdAMXgEUZlJckQ4w==",
 			"dev": true
 		},
 		"w3c-keyname": {

--- a/scripts/export-settings.ts
+++ b/scripts/export-settings.ts
@@ -26,6 +26,7 @@ export interface ExportSettingsData
 	// Export Options
 	dataviewBlockWaitTime: number;
 	showWarningsInExportLog: boolean;
+	incrementalExport: boolean;
 
 	// Page Features
 	addDarkModeToggle: boolean;
@@ -72,6 +73,7 @@ const DEFAULT_SETTINGS: ExportSettingsData =
 	// Export Options
 	dataviewBlockWaitTime: 700,
 	showWarningsInExportLog: true,
+	incrementalExport: false,
 
 	// Page Features
 	addDarkModeToggle: true,
@@ -430,6 +432,15 @@ export class ExportSettings extends PluginSettingTab {
 					await ExportSettings.saveSettings();
 				}));
 
+		new Setting(contentEl)
+			.setName('Incremental export')
+			.setDesc('Only export files that have changed since last export.')
+			.addToggle((toggle) => toggle
+			.setValue(ExportSettings.settings.incrementalExport)
+			.onChange(async (value) => {
+				ExportSettings.settings.incrementalExport = value;
+				await ExportSettings.saveSettings();
+			}));
 
 		//#endregion
 


### PR DESCRIPTION
## Done
Added a settings item: "Incremental export"
![image](https://github.com/KosmosisDire/obsidian-webpage-export/assets/479384/9d94e5c9-1516-437e-b8a7-b2165c6fad76)

When enabled, during an export, the files modified time is checked against the last time it was exported. If the file's modified time is before or equal to the last export time the file is skipped and a message is displayed.
![image](https://github.com/KosmosisDire/obsidian-webpage-export/assets/479384/32b2297b-793b-49c1-8ac2-63897d16c325)

Fixes: https://github.com/KosmosisDire/obsidian-webpage-export/issues/152

## QA
- Enable the feature
- Export your vault / a file - the first time will always export as there is no record of a file already being exported
- See that the vault / file is exported correctly - make a note of the files creation time
- Export your vaul / the file again
- See the Notice popup that files were skipped
- Check the files and compare to the previous file creation/ modified time, it shouldn't have changed
- Modify a file and repeat, check the modified time of the exported file is different
- Turn the setting off and repeat
- A new version of the file(s) should be there
- Rejoice in all the energy you've saved and how you've helped the planet.