### PR TITLE
Add sidebar buttons on mobile

### DIFF
--- a/assets/plugin-styles.txt.css
+++ b/assets/plugin-styles.txt.css
@@ -134,6 +134,51 @@
     flex-direction: row;
 }
 
+.sidebar-left, .sidebar-right {
+	transition: left 0.2s linear, right 0.2s linear;
+	top: 0;
+	bottom: 0;
+}
+
+.sidebar-left-active .sidebar-left {
+	left: 0 !important;
+}
+
+.sidebar-right-active .sidebar-right {
+	right: 0 !important;
+}
+
+.sidebar-mobile-btns {
+	padding: 5px 10px;
+	display: flex;
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	justify-content: space-between;
+	z-index: 1000;
+}
+
+.sidebar-mobile-btn--left, .sidebar-mobile-btn--right {
+	transition: left 0.2s linear, right 0.2s linear;
+}
+
+.sidebar-mobile-btn--left {
+	position: relative;
+	left: 0;
+}
+
+.sidebar-mobile-btn--right {
+	position: relative;
+	right: 0;
+}
+
+@media (min-width: 750px) {
+	.sidebar-mobile-btns {
+		display: none;
+	}
+}
+
 @media print 
 {
     .sidebar, .outline-container, .theme-toggle-container, .theme-toggle-container-inline, .toggle-background, .theme-toggle-input

--- a/assets/webpage.txt.js
+++ b/assets/webpage.txt.js
@@ -839,22 +839,26 @@ function setupResize(setupOnNode)
 
 		if (window.innerWidth < letHideRightThreshold)
 		{
-			rightSidebar.style.display = "none";
+			rightSidebar.style.position = "absolute";
+			rightSidebar.style.right = "-" + sidebarWidth + "px";
 		}
 		else
 		{
-			rightSidebar.style.display = "";
+			rightSidebar.style.position = "";
+			rightSidebar.style.right = "";
 		}
 
 		let letHideLeftThreshold = lineWidth / 2 + sidebarWidth;
 
 		if (window.innerWidth < letHideLeftThreshold)
 		{
-			leftSidebar.style.display = "none";
+			leftSidebar.style.position = "absolute";
+			leftSidebar.style.left = "-" + sidebarWidth + "px";
 		}
 		else
 		{
-			leftSidebar.style.display = "";
+			leftSidebar.style.position = "";
+			leftSidebar.style.left = "";
 		}
 	}
 
@@ -864,6 +868,43 @@ function setupResize(setupOnNode)
 	});
 
 	updateSidebars();
+}
+
+function sidebarClickHandler(event, btnEl, side, sidebarWidth) {
+	const sides = "leftright";
+	const opposite = sides.replace(side, "");
+	event.preventDefault();
+	event.stopImmediatePropagation();
+
+	let containerEl = document.querySelector(".webpage-container");
+
+	const width = sidebarWidth;
+	if (containerEl.classList.contains(`sidebar-${side}-active`)) {
+		containerEl.classList.remove(`sidebar-${side}-active`);
+		btnEl.style[side] = "";
+	} else {
+		containerEl.classList.add(`sidebar-${side}-active`);
+		btnEl.style[side] = `${width}px`;
+
+		if (containerEl.classList.contains(`sidebar-${opposite}-active`)) {
+			containerEl.classList.remove(`sidebar-${opposite}-active`);
+			document.querySelector(`.sidebar-mobile-btn--${opposite}`).style[opposite] = "";
+		}
+	}
+}
+
+function setupMobileSidebar(setupOnNode)
+{
+	if (setupOnNode != document) return;
+
+	let sidebarBtns = document.querySelector(".sidebar-mobile-btns");
+
+	let leftBtn = sidebarBtns.querySelector(".sidebar-mobile-btn--left");
+	let rightBtn = sidebarBtns.querySelector(".sidebar-mobile-btn--right");
+	let sidebarWidth = document.querySelector(".sidebar-left").getBoundingClientRect().width;
+
+	leftBtn.addEventListener("click", (e) => sidebarClickHandler(e, leftBtn, "left", sidebarWidth));
+	rightBtn.addEventListener("click", (e) => sidebarClickHandler(e, rightBtn, "right", sidebarWidth));
 }
 
 function setupRootPath(fromDocument)
@@ -887,6 +928,7 @@ function initializePage(setupOnNode)
 	setupCodeblocks(setupOnNode);
 	setupLinks(setupOnNode);
 	setupResize(setupOnNode);
+	setupMobileSidebar(setupOnNode);
 
 	setupOnNode.querySelectorAll("*").forEach(function(element)
 	{

--- a/scripts/html-generation/html-generator.ts
+++ b/scripts/html-generation/html-generator.ts
@@ -1,3 +1,4 @@
+import { setIcon } from "obsidian";
 import { Path } from "../utils/path";
 import { ExportSettings } from "../export-settings";
 import { GlobalDataGenerator, LinkTree } from "./global-gen";
@@ -30,6 +31,7 @@ export class HTMLGenerator
 		let usingDocument = file.document;
 
 		let sidebars = this.generateSideBars(file.contentElement, file);
+		this.generateSideBarBtns(file, sidebars);
 		let rightSidebar = sidebars.right;
 		let leftSidebar = sidebars.left;
 		usingDocument.body.appendChild(sidebars.container);
@@ -223,6 +225,7 @@ export class HTMLGenerator
 
 		/*
 		- div.webpage-container
+			- div.sidebar-mobile-btns
 
 			- div.sidebar-left
 				- div.sidebar-content
@@ -252,7 +255,7 @@ export class HTMLGenerator
 		rightContent.setAttribute("class", "sidebar-content");
 		rightSidebar.setAttribute("class", "sidebar-right");
 		rightSidebarScroll.setAttribute("class", "sidebar-scroll-area");
-		
+
 		leftSidebar.classList.add("sidebar");
 		leftSidebar.appendChild(leftContent);
 		// leftContent.appendChild(leftSidebarScroll);
@@ -267,7 +270,35 @@ export class HTMLGenerator
 		pageContainer.appendChild(documentContainer);
 		pageContainer.appendChild(rightSidebar);
 
+
 		return {container: pageContainer, left: leftContent, leftScroll: leftSidebarScroll, right: rightContent, rightScroll: rightSidebarScroll, center: documentContainer};
+	}
+
+	private static generateSideBarBtns(file: ExportFile, {left, right, container}: {left: HTMLElement, right: HTMLElement, container: HTMLElement}): {leftBtn: HTMLElement, rightBtn: HTMLElement, mobileSideBarBtns: HTMLElement}
+	{
+		const docEl = file.document;
+		/*
+		- div.sidebar-mobile-btns
+			- a.sidebar-mobile-btn--left
+			- a.sidebar-mobile-btn--right
+		*/
+
+		let mobileSideBarBtns = docEl.createElement("div");
+		const leftBtn = docEl.createElement("a");
+		const rightBtn = docEl.createElement("a");
+
+		mobileSideBarBtns.setAttribute("class", "sidebar-mobile-btns");
+		leftBtn.setAttribute("class", "sidebar-mobile-btn--left");
+		rightBtn.setAttribute("class", "sidebar-mobile-btn--right");
+
+		setIcon(leftBtn, "sidebar-left");
+		setIcon(rightBtn, "sidebar-right");
+
+		mobileSideBarBtns.appendChild(leftBtn);
+		mobileSideBarBtns.appendChild(rightBtn);
+		container.appendChild(mobileSideBarBtns);
+
+		return {leftBtn, rightBtn, mobileSideBarBtns};
 	}
 
 	private static getRelativePaths(file: ExportFile): {mediaPath: Path, jsPath: Path, cssPath: Path, rootPath: Path}


### PR DESCRIPTION
## Done
- Added icons for left and right sidenav for screens below 750px
- Make sidebars cover content when visible
- Only one sidebar open at a time

Caveats:
- Using a desktop browser in "responsive" mode causes double clicks on the buttons (no idea why, works fine on mobile)
- Hardcoded to below 750px in CSS, this doesn't take into account that until a certain width the right sidebar is still hidden 
- It doesn't handle resizes without a page load

Fixes https://github.com/KosmosisDire/obsidian-webpage-export/issues/19