### PR TITLE
Sort alphabetically and numerically

### DIFF
--- a/scripts/objects/tree.ts
+++ b/scripts/objects/tree.ts
@@ -92,7 +92,7 @@ export class Tree
 
 	public sortAlphabetically(reverse: boolean = false)
 	{
-		this.children.sort((a, b) => reverse ? b.title.localeCompare(a.title) : a.title.localeCompare(b.title));
+		this.children.sort((a, b) => reverse ? b.title.localeCompare(a.title, undefined, { numeric: true }) : a.title.localeCompare(b.title, undefined, { numeric: true }));
 		for (let child of this.children)
 		{
 			child.sortAlphabetically();
@@ -206,7 +206,7 @@ export class TreeItem
 
 	public sortAlphabetically(reverse: boolean = false)
 	{
-		this.children.sort((a, b) => reverse ? b.title.localeCompare(a.title) : a.title.localeCompare(b.title));
+		this.children.sort((a, b) => reverse ? b.title.localeCompare(a.title, undefined, { numeric: true }) : a.title.localeCompare(b.title, undefined, { numeric: true }));
 		for (let child of this.children)
 		{
 			child.sortAlphabetically();


### PR DESCRIPTION
The file tree on the web is sorted differently than in the Obsidian app. Numbers were sorted lexicographically, [1,2,3,8,9,10,11] as [1,10,11,2,3,8,9].

![numeric-sort](https://github.com/KosmosisDire/obsidian-webpage-export/assets/11784537/c3b9b6fc-30cc-4bee-a32f-a77a0c135d65)

