### PR TITLE
Feature: set display name of a page by frontmatter

### DIFF
--- a/scripts/objects/file-tree.ts
+++ b/scripts/objects/file-tree.ts
@@ -2,6 +2,7 @@ import { TAbstractFile, TFile, TFolder } from "obsidian";
 import { Tree, TreeItem } from "./tree";
 import { Path } from "scripts/utils/path";
 import { MarkdownRenderer } from "scripts/html-generation/markdown-renderer";
+import { Website } from "./website";
 
 export class FileTree extends Tree
 {
@@ -52,8 +53,8 @@ export class FileTree extends Tree
 				let path = new Path(file.path).makeUnixStyle();
 				if (file instanceof TFolder) path.makeForceFolder();
 				else if(!keepOriginalExtensions && MarkdownRenderer.isConvertable(path.extensionName)) path.setExtension("html");
-				parent.href = path.asString;
-				parent.title = path.basename == "." ? "" : path.basename;
+				parent.href = path.asString;			
+				parent.title = path.basename == "." ? "" : Website.getTitle(file);
 			}
 		}
 

--- a/scripts/objects/webpage.ts
+++ b/scripts/objects/webpage.ts
@@ -409,7 +409,7 @@ export class Webpage
 
 		let meta =
 		`
-		<title>${this.source.basename}</title>
+		<title>${Website.getTitle(this.source)}</title>
 		<base href="${relativePaths.rootPath}/">
 		<meta id="root-path" root-path="${relativePaths.rootPath}/">
 

--- a/scripts/objects/website.ts
+++ b/scripts/objects/website.ts
@@ -301,7 +301,7 @@ export class Website
 
 	public static getTitle(file: TFile) {
 		const { app } = HTMLExportPlugin.plugin;
-		return app.metadataCache.getFileCache(file)?.frontmatter?.title ?? file.basename;
+		const { titleProperty } = MainSettings.settings;
+		return app.metadataCache.getFileCache(file)?.frontmatter?.[titleProperty] ?? file.basename;
 	}
-
 }

--- a/scripts/objects/website.ts
+++ b/scripts/objects/website.ts
@@ -9,6 +9,7 @@ import { GraphView } from "./graph-view";
 import { Path } from "scripts/utils/path";
 import { RenderLog } from "scripts/html-generation/render-log";
 import { Utils } from "scripts/utils/utils";
+import HTMLExportPlugin from "scripts/main";
 
 const removeBodyClasses: string[] = ["mod-windows", "is-frameless", "is-maximized", "is-hidden-frameless", "obsidian-app", 
 								"show-view-header", "css-settings-manager", "Heading", "minimal-theme", "minimal-default-dark", 
@@ -296,6 +297,11 @@ export class Website
 		let json = JSON.stringify(data);
 		let databasePath = this.destination.directory.joinString("database.json");
 		await databasePath.writeFile(json);
+	}
+
+	public static getTitle(file: TFile) {
+		const { app } = HTMLExportPlugin.plugin;
+		return app.metadataCache.getFileCache(file)?.frontmatter?.title ?? file.basename;
 	}
 
 }

--- a/scripts/settings/main-settings.ts
+++ b/scripts/settings/main-settings.ts
@@ -15,6 +15,7 @@ export interface MainSettingsData
 	inlineImages: boolean;
 	includePluginCSS: string;
 	includeSvelteCSS: boolean;
+	titleProperty: string;
 	customHeadContentPath: string;
 
 	// Formatting Options
@@ -65,6 +66,7 @@ const DEFAULT_SETTINGS: MainSettingsData =
 	inlineImages: false,
 	includePluginCSS: '',
 	includeSvelteCSS: true,
+	titleProperty: 'webpage-title',
 	customHeadContentPath: '',
 
 	// Formatting Options
@@ -268,6 +270,17 @@ export class MainSettings extends PluginSettingTab
 					}
 					));
 		}
+
+		new Setting(contentEl)
+			.setName('Property name for title')
+			.setDesc('Use this property to specify the page title. This also affects how the page is displayed in the file tree.')
+			.addText((text) => text
+				.setValue(MainSettings.settings.titleProperty)
+				.onChange(async (value) => {
+					MainSettings.settings.titleProperty = value;
+					await MainSettings.saveSettings();
+				})
+			);
 
 		let errorMessage = contentEl.createDiv({ cls: 'setting-item-description' });
 		errorMessage.style.color = "var(--color-red)";


### PR DESCRIPTION
This PR is a partial solution for #241 and #153, and also related to #31.

First of all, thank you so much for this great plugin! I've rewrote the docs of my plugin using it, and it looks so cool!

https://ryotaushio.github.io/obsidian-math-booster/

The problem is, though, `index.html` has the title "index", but I want it to be something like "Math Booster Docs".
Currently, I don't have any idea but to manually (or using some script) modify `<title>` of the exported html.

Also, `index.html` appears as `index` in the file tree, which is not what I want.

So I propose letting users specify the page title via frontmatter, like so:

`Original Title.md`
```
---
title: Custom Title
---
Hello
```

This results in:

<img width="1552" alt="image" src="https://github.com/KosmosisDire/obsidian-webpage-export/assets/72342591/9a092641-52c4-4087-959b-86ee546d5f6c">

Note that "Custom Title" is displayed in both the page title (`<title>`) and the file tree.

What do you think? Let me know if you have any suggestions. Thank you!