### PR TITLE
- Preserve excalidraw mask fill

### DIFF
--- a/assets/plugin-styles.txt.css
+++ b/assets/plugin-styles.txt.css
@@ -1221,6 +1221,20 @@ input[type="search"]
 	fill: transparent;
 }
 
+/** Preserve mask fill **/
+.excalidraw-plugin mask rect[fill="#fff"],
+.excalidraw-svg mask rect[fill="#fff"],
+.excalidraw-plugin mask rect[fill="#ffffff"],
+.excalidraw-svg mask rect[fill="#ffffff"]{
+    fill: #ffffff;
+}
+.excalidraw-plugin mask rect[fill="#000"],
+.excalidraw-svg mask rect[fill="#000"],
+.excalidraw-plugin mask rect[fill="#000000"],
+.excalidraw-svg mask rect[fill="#000000"]{
+    fill: #000000;
+}
+
 body.theme-dark .excalidraw-svg svg.dark, body.theme-dark .excalidraw-plugin svg.dark,
 body.theme-light .excalidraw-svg svg.light, body.theme-light .excalidraw-plugin svg.light
 {


### PR DESCRIPTION
**Fixes Excalidraw exports that have labeled lines.**

Currently labeled lines are hidden as a side effect of setting the fill of all rects to transparent. Labeled lines use a mask to hide the area where the label sits above the line and when the rects of the mask have their fill is set to transparent it causes the entire mask to be transparent causing the line of the labeled line to be masked out.

## Before Fix
![before fix](https://raw.githubusercontent.com/iyioio/obsidian-webpage-export/example-images/example-images/before.png)

Added CSS:
``` css
/** Preserve mask fill **/
.excalidraw-plugin mask rect[fill="#fff"],
.excalidraw-svg mask rect[fill="#fff"],
.excalidraw-plugin mask rect[fill="#ffffff"],
.excalidraw-svg mask rect[fill="#ffffff"]{
    fill: #ffffff;
}
.excalidraw-plugin mask rect[fill="#000"],
.excalidraw-svg mask rect[fill="#000"],
.excalidraw-plugin mask rect[fill="#000000"],
.excalidraw-svg mask rect[fill="#000000"]{
    fill: #000000;
}
```

## After Fix
![after fix](https://raw.githubusercontent.com/iyioio/obsidian-webpage-export/example-images/example-images/after.png)
