### PR TITLE
Fix data-heading to id convertion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
-				"electron": "^26.1.0",
+				"electron": "^26.6.10",
 				"esbuild": "0.14.47",
 				"eslint": "^8.57.0",
 				"globals": "^15.0.0",
@@ -1436,9 +1436,9 @@
 			"integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
 		},
 		"node_modules/electron": {
-			"version": "26.6.8",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-26.6.8.tgz",
-			"integrity": "sha512-nuzJ5nVButL1jErc97IVb+A6jbContMg5Uuz5fhmZ4NLcygLkSW8FZpnOT7A4k8Saa95xDJOvqGZyQdI/OPNFw==",
+			"version": "26.6.10",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-26.6.10.tgz",
+			"integrity": "sha512-pV2SD0RXzAiNRb/2yZrsVmVkBOMrf+DVsPulIgRjlL0+My9BL5spFuhHVMQO9yHl9tFpWtuRpQv0ofM/i9P8xg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -5294,9 +5294,9 @@
 			"integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
 		},
 		"electron": {
-			"version": "26.6.8",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-26.6.8.tgz",
-			"integrity": "sha512-nuzJ5nVButL1jErc97IVb+A6jbContMg5Uuz5fhmZ4NLcygLkSW8FZpnOT7A4k8Saa95xDJOvqGZyQdI/OPNFw==",
+			"version": "26.6.10",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-26.6.10.tgz",
+			"integrity": "sha512-pV2SD0RXzAiNRb/2yZrsVmVkBOMrf+DVsPulIgRjlL0+My9BL5spFuhHVMQO9yHl9tFpWtuRpQv0ofM/i9P8xg==",
 			"dev": true,
 			"requires": {
 				"@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
 		"builtin-modules": "3.3.0",
-		"electron": "^26.1.0",
+		"electron": "^26.6.10",
 		"esbuild": "0.14.47",
 		"eslint": "^8.57.0",
 		"globals": "^15.0.0",

--- a/src/plugin/website/webpage.ts
+++ b/src/plugin/website/webpage.ts
@@ -596,15 +596,33 @@ export class Webpage extends Attachment
 
 	private remapLinks()
 	{
-		this.pageDocument.querySelectorAll("h1, h2, h3, h4, h5, h6").forEach((headerEl) =>
-		{
-			// convert the data-heading to the id
-			headerEl.setAttribute("id", this.headingTextToID(headerEl.getAttribute("data-heading") ?? headerEl.textContent));
-		});
+		// convert the data-heading to the id
+
+		const hMap = new Map();
+
+		this.pageDocument
+			.querySelectorAll("h1, h2, h3, h4, h5, h6")
+			.forEach((headerEl) => {
+				let headerText =
+					headerEl.getAttribute("data-heading") ??
+					headerEl.textContent;
+				let headerId = hMap.get(headerText);
+				if (headerId) {
+					headerId = `${+headerId + 1}`;
+				} else {
+					headerId = "0";
+				}
+
+				hMap.set(headerText, headerId);
+
+				headerEl.setAttribute(
+					"id",
+					`${headerText}_${headerId}`.replaceAll(" ", "_") ?? ""
+				);
+			});
 
 		const links = this.hrefLinkElements;
-		for (const link of links)
-		{
+		for (const link of links) {
 			const href = link.getAttribute("href");
 			const newHref = this.resolveLink(href);
 			link.setAttribute("href", newHref ?? href ?? "");


### PR DESCRIPTION
Hi! Just added unique number for each heading, so links to headings with the same name (same data-heading attribute) work properly now

For some reason npm won't install electron 26.1.0 giving an error so I changed it to a bit newer version

My first contribution btw. Wonder if it is helpful, huh