### PR TITLE
fix: ignore typescript error

### DIFF
--- a/src/plugin/website/webpage.ts
+++ b/src/plugin/website/webpage.ts
@@ -421,7 +421,7 @@ export class Webpage extends Attachment
 	{
 		// @ts-ignore
 		const backlinks = Array.from(app.metadataCache.getBacklinksForFile(this.source)?.data?.keys?.() || []);
-		let linkedWebpages = backlinks.map((path) => this.website.index.getWebpage(path)) as Webpage[];
+		let linkedWebpages = backlinks.map((path: string) => this.website.index.getWebpage(path)) as Webpage[];
 		linkedWebpages = linkedWebpages.filter((page) => page != undefined);
 		return linkedWebpages;
 	}


### PR DESCRIPTION
I am not a typescript developer but I need this to "npm run build". And I see that "path" is not defined locally and must appear through some scope-magic.