### PR TITLE
feat: remove existing feature before inserting new one

### DIFF
--- a/src/shared/features/feature-options-base.ts
+++ b/src/shared/features/feature-options-base.ts
@@ -122,6 +122,12 @@ export class InsertedFeatureOptions extends FeatureOptions
 	public insertFeature(container: HTMLElement, feature: HTMLElement): boolean
 	{
 		if (!container) return false;
+		if (feature.id) {
+			const existingFeature = container.querySelector(`#${feature.id}`);
+			if (existingFeature) {
+				existingFeature.remove();
+			}
+		}
 		let relation = container.querySelector(this.featurePlacement.selector) as HTMLElement;
 		if (relation)
 		{


### PR DESCRIPTION
I know this is not the proper solution for #548 and I understand what should be done there. I am not sure I can do all of it.

But in the meantime, it still seems correct to not add a feature over and over again, even though backlinks should not do that in the first place.