### PR TITLE
feat: Add recursive export of linked notes

### DIFF
--- a/scripts/exporter.ts
+++ b/scripts/exporter.ts
@@ -6,6 +6,43 @@ import { Utils } from "./utils/utils";
 import { Website } from "./objects/website";
 import { MarkdownRendererAPI } from "./render-api";
 
+class LinkCollector {
+    static async collectLinkedFiles(
+        files: TFile[], 
+        maxDepth: number = Settings.recursiveExportDepth
+    ): Promise<TFile[]> {
+        const visited = new Set<string>();
+        const result: TFile[] = [];
+
+        async function collect(file: TFile, currentDepth: number) {
+            if (currentDepth > maxDepth) return;
+            if (visited.has(file.path)) return;
+            
+            visited.add(file.path);
+            result.push(file);
+
+            const cache = app.metadataCache.getFileCache(file);
+            const links = [
+                ...(cache?.links?.map(l => l.link) || []),
+                ...(cache?.embeds?.map(l => l.link) || [])
+            ];
+
+            await Promise.all(links.map(async link => {
+                const linkedFile = app.metadataCache.getFirstLinkpathDest(link, file.path);
+                if (linkedFile?.extension === "md") {
+                    await collect(linkedFile, currentDepth + 1);
+                }
+            }));
+        }
+
+        await Promise.all(files.map(file => 
+            collect(file, 1) // 从深度1开始计数
+        ));
+
+        return result;
+    }
+}
+
 export class HTMLExporter
 {
 	public static async export(usePreviousSettings: boolean = true, overrideFiles: TFile[] | undefined = undefined, overrideExportPath: Path | undefined = undefined)
@@ -25,6 +62,10 @@ export class HTMLExporter
 
 	public static async exportFiles(files: TFile[], destination: Path, saveFiles: boolean, deleteOld: boolean) : Promise<Website | undefined>
 	{
+		if (Settings.recursiveExport) {
+			files = await LinkCollector.collectLinkedFiles(files);
+			files = [...new Set(files)];
+		}
 		var website = await new Website().createWithFiles(files, destination);
 
 		if (!website)

--- a/scripts/settings/export-modal.ts
+++ b/scripts/settings/export-modal.ts
@@ -194,6 +194,32 @@ export class ExportModal extends Modal
 				));
 		exportModeSetting.descEl.style.whiteSpace = "pre-wrap";
 
+		SettingsPage.createToggle(contentEl, "Recursive Export",
+			() => Settings.recursiveExport, 
+			(value) => Settings.recursiveExport = value)
+		.setDesc("Export linked files as well as the selected files.");
+
+		if (Settings.recursiveExport) {
+			SettingsPage.createText(
+				contentEl,
+				"Max recursive depth",
+				() => Settings.recursiveExportDepth.toString(),
+				(value) => {
+					const num = parseInt(value);
+					if (!isNaN(num)) {
+						Settings.recursiveExportDepth = num;
+					}
+				},
+				"number",
+				(value) => {
+					const num = parseInt(value);
+					if (isNaN(num)) return "Not a number";
+					return "";
+				}
+			).setClass("number-input-field");
+		}
+
+
 		SettingsPage.createToggle(contentEl, "Open after export", () => Settings.openAfterExport, (value) => Settings.openAfterExport = value);
 		
 		let exportButton : ButtonComponent | undefined = undefined;

--- a/scripts/settings/settings.ts
+++ b/scripts/settings/settings.ts
@@ -55,6 +55,8 @@ export class Settings
 	public static makeNamesWebStyle: boolean;
 	public static onlyExportModified: boolean;
 	public static deleteOldFiles: boolean;
+	public static recursiveExport: boolean;
+	public static recursiveExportDepth: number;
 
 	// Page Features
 	public static addThemeToggle: boolean;
@@ -123,6 +125,8 @@ export const DEFAULT_SETTINGS: Settings =
 	makeNamesWebStyle: true,
 	onlyExportModified: true,
 	deleteOldFiles: true,
+	recursiveExport: false,
+	recursiveExportDepth: 3,
 	
 	// Page Features
 	addThemeToggle: true,


### PR DESCRIPTION
This feature enables exporting linked notes (one-way only) with a customizable depth option.

⚠️⚠️⚠️⚠️ 100% of the code is AI-generated because I hate JavaScript so much, and I'm unfamiliar with Obsidian plugins. 
⚠️⚠️⚠️⚠️ But at least I tested it and confirmed it works.  
⚠️⚠️⚠️⚠️ Please have an Obsidian expert review my BS code before using or merging this.  

Sorry for wasting your time but I really need this feature.

link issue #38