### PR TITLE
Skip note export if it has property publish='false'

### DIFF
--- a/src/plugin/settings/settings.ts
+++ b/src/plugin/settings/settings.ts
@@ -44,6 +44,7 @@ export class Settings
 	public static deleteOldFiles: boolean = true;
 	public static exportPreset: ExportPreset = ExportPreset.Online;
 	public static openAfterExport: boolean = true;
+	public static enablePublishFiltering: boolean = true;
 
 	// Graph View Settings
 	public static filePickerBlacklist: string[] = ["(^|\\/)node_modules\\/","(^|\\/)dist\\/","(^|\\/)dist-ssr\\/","(^|\\/)\\.vscode\\/"]; // ignore node_modules, dist, and .vscode
@@ -350,6 +351,11 @@ export class SettingsPage extends PluginSettingTab
 			() => Settings.exportOptions.offlineResources,
 			(value) => Settings.exportOptions.offlineResources = value,
 			lang.makeOfflineCompatible.description);
+
+		createToggle(section, lang.enablePublishFiltering.title,
+			() => Settings.enablePublishFiltering,
+			(value) => Settings.enablePublishFiltering = value,
+			lang.enablePublishFiltering.description);
 
 		// #endregion
 

--- a/src/plugin/translations/en.ts
+++ b/src/plugin/translations/en.ts
@@ -182,6 +182,10 @@ export const language: i18n =
 			title: "General Settings",
 			description: "Control simple settings like the favicon and site metadata",
 		},
+		enablePublishFiltering: {
+			title: "Enable Publish Property Filtering",
+			description: "When enabled, files with publish=false in frontmatter will be excluded from export",
+		},
 		favicon: {
 			title: "Favicon image",
 			description: "The local path to the favicon for the site",

--- a/src/plugin/translations/it.ts
+++ b/src/plugin/translations/it.ts
@@ -175,6 +175,10 @@ export const language: i18n =
 			title: "Impostazioni Generali",
 			description: "Controlla impostazioni semplici come favicon e metadati del sito",
 		},
+		enablePublishFiltering: {
+			title: "Abilita Filtro Proprietà di Pubblicazione",
+			description: "Quando abilitato, i file con publish=false nel frontmatter saranno esclusi dall'esportazione",
+		},
 		favicon: {
 			title: "Immagine Favicon",
 			description: "Il percorso locale della favicon per il sito",

--- a/src/plugin/translations/language.ts
+++ b/src/plugin/translations/language.ts
@@ -230,6 +230,10 @@ export interface i18n
 			title: string;
 			description: string;
 		},
+		enablePublishFiltering: {
+			title: string;
+			description: string;
+		},
 
 	}
 }

--- a/src/plugin/translations/pt.ts
+++ b/src/plugin/translations/pt.ts
@@ -181,6 +181,10 @@ export const language: i18n =
 			title: "Configurações Gerais",
 			description: "Controle configurações simples como favicon e metadados do site",
 		},
+		enablePublishFiltering: {
+			title: "Ativar Filtragem por Propriedade de Publicação",
+			description: "Quando ativado, arquivos com publish=false no frontmatter serão excluídos da exportação",
+		},
 		favicon: {
 			title: "Imagem do Favicon",
 			description: "Caminho local da imagem favicon do site",

--- a/src/plugin/translations/uk.ts
+++ b/src/plugin/translations/uk.ts
@@ -180,6 +180,10 @@ export const language: i18n =
 			title: "Загальні налаштування",
 			description: "Керування простими налаштуваннями, такими як favicon та метадані сайту",
 		},
+		enablePublishFiltering: {
+			title: "Увімкнути фільтрацію за властивістю публікації",
+			description: "Коли увімкнено, файли з publish=false у frontmatter будуть виключені з експорту",
+		},
 		favicon: {
 			title: "Зображення Favicon",
 			description: "Локальний шлях до favicon для сайту",

--- a/src/plugin/translations/zh-cn.ts
+++ b/src/plugin/translations/zh-cn.ts
@@ -181,6 +181,10 @@ export const language: i18n =
 			title: "通用设置",
 			description: "控制网站图标和站点元数据等简单设置",
 		},
+		enablePublishFiltering: {
+			title: "启用发布属性过滤",
+			description: "启用后，前置元数据中包含 publish=false 的文件将被排除在导出之外",
+		},
 		favicon: {
 			title: "网站图标",
 			description: "站点的网站图标的本地路径",

--- a/src/plugin/website/website.ts
+++ b/src/plugin/website/website.ts
@@ -121,7 +121,21 @@ export class Website
 		ExportLog.addToProgressCap((files?.length ?? 0));
 		ExportLog.addToProgressCap((files?.length ?? 0) * 0.1);
 
-		this.sourceFiles = files?.filter((file) => file) ?? [];
+		this.sourceFiles = files?.filter((file) => {
+			// Filter out null files
+			if (!file) return false;
+			
+			// Filter out files with publish=false in frontmatter if enabled
+			if (Settings.enablePublishFiltering) {
+				const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
+				if (frontmatter && (frontmatter.publish === "false" || frontmatter.publish === false)) {
+					ExportLog.log(`Skipping file with publish=false: ${file.path}`);
+					return false;
+				}
+			}
+
+			return true;
+		}) ?? [];
 
 		let rootPath = this.findCommonRootPath(this.sourceFiles);
 		this.exportOptions.exportRoot = rootPath;


### PR DESCRIPTION
# Publish Property Filtering

## Overview

This feature adds the ability to filter out files from the export process based on a `publish` property in the frontmatter. Files with `publish: false` will be excluded from the export.

## Implementation Details

The implementation adds a check in the `Website.load()` method that filters out files where the frontmatter contains `publish: false`. This allows users to mark specific files as not for publication while keeping them in their vault.

### Code Changes

The filtering logic was added to the `website.ts` file in the `load` method:

```typescript
this.sourceFiles = files?.filter((file) => {
    // Filter out null files
    if (!file) return false;
    
    // Filter out files with publish=false in frontmatter
    const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
    if (frontmatter && frontmatter.publish === false) {
        ExportLog.info(`Skipping file with publish=false: ${file.path}`);
        return false;
    }
    
    return true;
}) ?? [];
```

## Usage

To mark a file as not for publication, add the following to the frontmatter at the top of the file:

```yaml
---
publish: false
---
```

Files without a `publish` property or with `publish: true` will be included in the export as normal.

## Testing

To test this feature:

1. Create files with different publish settings:
   - A file with `publish: false` in the frontmatter
   - A file with `publish: true` in the frontmatter
   - A file with no publish property

2. Export the files using the plugin

3. Verify that:
   - Files with `publish: false` are not exported
   - Files with `publish: true` are exported
   - Files with no publish property are exported

## Example

### File that will be exported:
```markdown
---
title: My Public Note
publish: true
---

# My Public Note
This content will be exported.
```

### File that will NOT be exported:
```markdown
---
title: My Private Note
publish: false
---

# My Private Note
This content will NOT be exported.
```
