### PR TITLE
Return the code for icons in file tree from 1.9.0-3b

### DIFF
--- a/src/plugin/features/file-tree.ts
+++ b/src/plugin/features/file-tree.ts
@@ -120,9 +120,11 @@ export class FileTree extends Tree
 					if (targetPath.path.endsWith(".excalidraw.md")) targetPath.setExtension("drawing");
 					currentParentNode.originalExtension = file.extensionName;
 					if(!this.keepOriginalExtensions && MarkdownRendererAPI.isConvertable(targetPath.extensionName)) targetPath.setExtension("html");
-				    if (tfile) currentParentNode.title = (await _MarkdownRendererInternal.getTitleForFile(tfile)).title;
-                }
-
+				    if (tfile) {
+						currentParentNode.title = (await _MarkdownRendererInternal.getTitleForFile(tfile)).title;
+						currentParentNode.icon = (await _MarkdownRendererInternal.getIconForFile(tfile)).icon;
+					}
+				}
 				currentParentNode.href = targetPath.path; // This is the output href
 			}
 		}


### PR DESCRIPTION
**Related issue**: #656 
This PR returns the code for displaying icons in the file tree.
**Source**: 1.9.0-3b

<img width="1482" height="428" alt="image" src="https://github.com/user-attachments/assets/9999de9d-bfda-4436-b86f-bd4f6370db79" />