### PR TITLE
Fixes #717. Update collapsible sidebar icon to match the obsidian's icon

### DIFF
--- a/src/assets/deferred.txt.css
+++ b/src/assets/deferred.txt.css
@@ -170,18 +170,22 @@ body
 }
 
 #left-sidebar .clickable-icon.sidebar-collapse-icon {
-    transform: rotateY(180deg);
     right: var(--sidebar-margin);
 }
 
 #right-sidebar .clickable-icon.sidebar-collapse-icon {
-    transform: rotateY(180deg);
+	transform: scaleX(-1);
+	transform-origin: center;
     left: var(--sidebar-margin);
 }
 
 .clickable-icon.sidebar-collapse-icon svg.svg-icon {
-    width: 100%;
-    height: 100%;
+    width: 80%;
+    height: 80%;
+}
+
+.sidebar:not(.is-collapsed) .clickable-icon.sidebar-collapse-icon svg.svg-icon .sidebar-toggle-icon-inner {
+	width: 24%;
 }
 
 .feature-title {

--- a/src/plugin/website/webpage-template.ts
+++ b/src/plugin/website/webpage-template.ts
@@ -25,7 +25,7 @@ export class WebpageTemplate
 	{
 		this.doc = document.implementation.createHTMLDocument();
 
-		const collapseSidebarIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" class="svg-icon"><path d="M21 3H3C1.89543 3 1 3.89543 1 5V19C1 20.1046 1.89543 21 3 21H21C22.1046 21 23 20.1046 23 19V5C23 3.89543 22.1046 3 21 3Z"></path><path d="M10 4V20"></path><path d="M4 7H7"></path><path d="M4 10H7"></path><path d="M4 13H7"></path></svg>`;
+		const collapseSidebarIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="svg-icon sidebar-toggle-button-icon"><rect x="1" y="2" width="22" height="20" rx="4"></rect><rect x="4" y="5" width="2" height="14" rx="2" fill="currentColor" class="sidebar-toggle-icon-inner"></rect></svg>`;
 		
 		const head = this.doc.head;
 		head.innerHTML = `<meta charset="UTF-8">` + head.innerHTML;


### PR DESCRIPTION
This PR upgrade the the old icon for collapse sidebar and add visual animation that show if sidebar is open or not, like obsidian.

When Sidebar is open
<img width="1919" height="154" alt="Captura de pantalla 2026-01-09 195853" src="https://github.com/user-attachments/assets/5d039f3e-3a37-4506-8ecc-09cd4bd7c0d7" />

When Sidebar is closed
<img width="1919" height="230" alt="Captura de pantalla 2026-01-10 003423" src="https://github.com/user-attachments/assets/d3914fce-61e9-4022-bacb-d6d343643b4b" />
